### PR TITLE
Fix bounding rect bug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "dev",
+			"problemMatcher": [],
+			"label": "dev server",
+			"detail": "next dev",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/components/fullHeader.jsx
+++ b/components/fullHeader.jsx
@@ -45,7 +45,15 @@ export default function FullHeader() {
     // Note: this isn't a very React way to do this. I think we should be using refs
     useEffect(() => {
         const updateActive = () => {
-            const scrollPositions = getScrollPositions(Object.keys(SECTIONS));
+            let scrollPositions;
+
+            try {
+                scrollPositions = getScrollPositions(Object.keys(SECTIONS));
+            } catch (error) {
+                console.warn('Failed to find sections, likely because they have been unmounted') 
+
+                return
+            }
 
             let newActiveSection = activeSectionId;
 

--- a/components/fullHeader.jsx
+++ b/components/fullHeader.jsx
@@ -41,31 +41,31 @@ export default function FullHeader() {
     const [navOpen, setNavOpen] = useState(false); // Track if the navbar menu is open on small devices
     const [activeSectionId, setActiveSectionId] = useState(null); // Track which section id is active
 
+    const updateActive = () => {
+        let scrollPositions;
+
+        try {
+            scrollPositions = getScrollPositions(Object.keys(SECTIONS));
+        } catch (error) {
+            console.warn('Failed to find sections, likely because they have been unmounted') 
+
+            return
+        }
+
+        let newActiveSection = activeSectionId;
+
+        for (const [sectionId, position] of Object.entries(scrollPositions)) {
+            if (position < 100) {
+                newActiveSection = sectionId
+            }
+        }
+
+        setActiveSectionId(newActiveSection); 
+    }
+
     // Mount an event listener to track and update the scroll positions 
     // Note: this isn't a very React way to do this. I think we should be using refs
     useEffect(() => {
-        const updateActive = () => {
-            let scrollPositions;
-
-            try {
-                scrollPositions = getScrollPositions(Object.keys(SECTIONS));
-            } catch (error) {
-                console.warn('Failed to find sections, likely because they have been unmounted') 
-
-                return
-            }
-
-            let newActiveSection = activeSectionId;
-
-            for (const [sectionId, position] of Object.entries(scrollPositions)) {
-                if (position < 100) {
-                    newActiveSection = sectionId
-                }
-            }
-    
-            setActiveSectionId(newActiveSection); 
-        }
-
         updateActive()
         window.addEventListener('scroll', updateActive);
 


### PR DESCRIPTION
Closes #27. Note that this does just provide a warning instead, but I think there's a race condition that's present that is causing the inconsistent behavior. I suspect that sometimes the section on the homepage unmount slightly before the full header does, so the event is triggered at just the wrong time. Perhaps this can be better resolved when #4 is resolved later on, but I think this is fine for now