### PR TITLE
Fix style null bug

### DIFF
--- a/components/scrollingTitle.jsx
+++ b/components/scrollingTitle.jsx
@@ -82,7 +82,9 @@ export default function ScrollingTitle({ titles }) {
         const animationDuration = parseFloat(computedStyles['animation-duration'].replace('ms', '')) * 1000;
 
         // Schedule making the title visible when the animation ends
-        setTimeout(() => setActiveTitle((activeTitle + 1) % titles.length), animationDuration)
+        let a = setTimeout(() => setActiveTitle((activeTitle + 1) % titles.length), animationDuration)
+
+        console.log(a);
     }, [activeTitle])
 
     // Add an event listner to update the title size when the width changes
@@ -91,6 +93,10 @@ export default function ScrollingTitle({ titles }) {
         window.addEventListener('resize', updateContainerSize)
 
         updateContainerSize()
+
+        return () => {
+            window.removeEventListener('resize', updateContainerSize)
+        }
     }, [])
 
     return (

--- a/components/scrollingTitle.jsx
+++ b/components/scrollingTitle.jsx
@@ -7,6 +7,8 @@ export default function ScrollingTitle({ titles }) {
 
     const containerRef = useRef(null);  // Reference to the container, from which children can be accessed
 
+    let updateTimeout; // Refernce to the timeout to update the active title, so it can be canceled when unmounted
+
     /**
      * Utility to clear the size constraints of the title container
      * So that when we test the title sizes, they can take up us much space as needed
@@ -82,9 +84,11 @@ export default function ScrollingTitle({ titles }) {
         const animationDuration = parseFloat(computedStyles['animation-duration'].replace('ms', '')) * 1000;
 
         // Schedule making the title visible when the animation ends
-        let a = setTimeout(() => setActiveTitle((activeTitle + 1) % titles.length), animationDuration)
+        updateTimeout = setTimeout(() => setActiveTitle((activeTitle + 1) % titles.length), animationDuration)
 
-        console.log(a);
+        return () => {
+            clearTimeout(updateTimeout);
+        }
     }, [activeTitle])
 
     // Add an event listner to update the title size when the width changes


### PR DESCRIPTION
Closes #26 and a related error that hadn't been documented that was caused by the timeout on the scrolling title element not being cleared upon unmount